### PR TITLE
MDEV-18515: The wsrep_cluster_weight status variable is not supported

### DIFF
--- a/gcomm/src/pc.cpp
+++ b/gcomm/src/pc.cpp
@@ -221,6 +221,8 @@ void gcomm::PC::close(bool force)
 void gcomm::PC::handle_get_status(gu::Status& status) const
 {
     status.insert("gcomm_uuid", uuid().full_str());
+    status.insert("cluster_weight", gu::to_string(
+                      pc_ ? pc_->cluster_weight() : 0));
 }
 
 gcomm::PC::PC(Protonet& net, const gu::URI& uri) :

--- a/gcomm/src/pc_proto.cpp
+++ b/gcomm/src/pc_proto.cpp
@@ -634,7 +634,22 @@ void gcomm::pc::Proto::handle_view(const View& view)
 }
 
 
-
+int gcomm::pc::Proto::cluster_weight() const
+{
+    int total_weight(0);
+    if (pc_view_.type() == V_PRIM)
+    {
+        for (NodeMap::const_iterator i(instances_.begin());
+             i != instances_.end(); ++i)
+        {
+            if (pc_view_.id() == i->second.last_prim())
+            {
+                total_weight += i->second.weight();
+            }
+        }
+    }
+    return total_weight;
+}
 
 // Validate state message agains local state
 void gcomm::pc::Proto::validate_state_msgs() const

--- a/gcomm/src/pc_proto.hpp
+++ b/gcomm/src/pc_proto.hpp
@@ -190,6 +190,7 @@ public:
                    rst_view -> id().seq()));
     }
     const View* restored_view() const { return rst_view_; }
+    int cluster_weight() const;
 private:
     friend std::ostream& operator<<(std::ostream& os, const Proto& p);
     Proto (const Proto&);


### PR DESCRIPTION
Current version of Galera does not support the wsrep_cluster_weight
status variable, which causes the galera_pc_weight test (from the
galera_3nodes suite) to fail.

This patch adds the missing variable to the wsrep status variables.

https://jira.mariadb.org/browse/MDEV-18515